### PR TITLE
remove redundant "Trademark"

### DIFF
--- a/CPM/Collaborative-Mark-Policy-draft.md
+++ b/CPM/Collaborative-Mark-Policy-draft.md
@@ -20,7 +20,7 @@ This policy applies to all trademarks of the Community. The trademarks are both 
 This policy applies whenever you want to use the Community marks. Section 2 of this policy applies to all uses of the marks. Other sections apply only to uses that do not require separate permission, uses that require a trademark license, or uses under agreements held by `[insert groups/organizations recognized by the community, if any (e.g. user groups)]`. If some term in your trademark license is inconsistent with this policy, you should follow the license terms. 
 
 ### 2.3. “We” or the “Trademark steward”
-This policy regulates the use of marks held by the `[organization or individual that holds the marks]`, who acts as a Trademark steward for the Community marks.  Sometimes, this policy simply refers to the Trademark steward as “we.” 
+This policy regulates the use of marks held by the `[organization or individual that holds the marks]`, who acts as a steward for the Community marks.  Sometimes, this policy simply refers to the Trademark steward as “we.” 
 
 ### 1.4. “You”
 This policy applies to “you” if you want to use the Community marks and explains how you may use them. You may be a member of Community or an unrelated individual or organization. 


### PR DESCRIPTION
"Trademark" in "acts as a Trademark steward for the Community marks" is redundant (what other kind of steward would you be for marks?); this pull removes it.
